### PR TITLE
Ignore CA as it may cause extended validation errors

### DIFF
--- a/internal/controller/sync.go
+++ b/internal/controller/sync.go
@@ -437,7 +437,6 @@ func (r *Route) populateRoute(ctx context.Context, route *routev1.Route, cr *cma
 	route.Spec.TLS.Key = string(encodedKey)
 	delete(route.Annotations, cmapi.IsNextPrivateKeySecretLabelKey)
 	route.Spec.TLS.Certificate = string(cr.Status.Certificate)
-	route.Spec.TLS.CACertificate = string(cr.Status.CA)
 
 	_, err = r.routeClient.RouteV1().Routes(route.Namespace).Update(ctx, route, metav1.UpdateOptions{})
 	return err


### PR DESCRIPTION
The CA field in the cert-manager CertificateRequest may not be set, or be useful at all. I've had reports of having the CA set causing extendedValidation errors in openshift, so I'd rather ignore the CA field entirely for now.