### PR TITLE
Verify that certificate is valid for Route hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ The route's TLS certificate will be rotated 2/3 of the way through the certifica
 
 Now the website can be called: https://app.service.clustername.domain.com
 
+## Development
+
+The source code for the controller can be found in the `./internal/` folder.
+After modifying the source code, you can execute the tests with:
+
+```sh
+go test ./...
+```
+
 # Why is This a Separate Project?
 
 We do not wish to support non Kubernetes (or kubernetes-sigs) APIs in cert-manager core. This adds

--- a/internal/controller/sync.go
+++ b/internal/controller/sync.go
@@ -144,6 +144,11 @@ func (r *Route) hasValidCertificate(route *routev1.Route) bool {
 		r.eventRecorder.Event(route, corev1.EventTypeNormal, ReasonIssuing, "Issuing cert as the public key does not match the certificate")
 		return false
 	}
+	// Cert matches Route hostname?
+	if err := cert.VerifyHostname(route.Spec.Host); err != nil {
+		r.eventRecorder.Event(route, corev1.EventTypeNormal, ReasonIssuing, "Issuing cert as the hostname does not match the certificate")
+		return false
+	}
 	// Still not after the renew-before window?
 	if metav1.HasAnnotation(route.ObjectMeta, cmapi.RenewBeforeAnnotationKey) {
 		renewBeforeDuration, err := time.ParseDuration(route.Annotations[cmapi.RenewBeforeAnnotationKey])

--- a/internal/controller/sync_test.go
+++ b/internal/controller/sync_test.go
@@ -284,6 +284,29 @@ SOME GARBAGE
 			want:         false,
 			wantedEvents: []string{"Normal Issuing Issuing cert as no TLS is configured"},
 		},
+		{
+			name: "changed route hostname triggers new certificate",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "some-route",
+					Namespace:         "some-namespace",
+					CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Hour * 24 * 30)},
+					Annotations:       map[string]string{cmapi.IssuerNameAnnotationKey: "some-issuer"},
+				},
+				Spec: routev1.RouteSpec{
+					Host: "some-other-host.some-domain.tld",
+					TLS: &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationEdge,
+						Certificate:                   string(validEcdsaCertPEM),
+						Key:                           string(ecdsaKeyPEM),
+						CACertificate:                 string(validEcdsaCertPEM),
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+					},
+				},
+			},
+			want:         false,
+			wantedEvents: []string{"Normal Issuing Issuing cert as the hostname does not match the certificate"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
At the moment, the `hasValidCertificate` function does not check if the certificate is valid for the current route hostname.
https://github.com/cert-manager/openshift-routes/blob/main/internal/controller/sync.go#L108

Since `Route.spec.host` can be updated in-place, it might happen that the hostname changes over the lifetime of a Route, which should be reflected this this controller in the form of issuing / requesting a new certificate.

This patch implements the desired behavior and adds a test case for it.

Closes https://github.com/cert-manager/openshift-routes/issues/21