### PR TITLE
Document release process and update the versions of the GitHub Actions workflows

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -27,7 +27,7 @@ jobs:
           # The reason we don't use `go-version: go.mod` is because go.mod's
           # version is the minimal required version. But for building the
           # binaries, we want to use a Go version that is still supported.
-          go-version: "^1.20"
+          go-version: "^1.21"
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -22,16 +22,19 @@ jobs:
       - name: Fetch all tags
         run: git fetch --force --tags
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
+          # The reason we don't use `go-version: go.mod` is because go.mod's
+          # version is the minimal required version. But for building the
+          # binaries, we want to use a Go version that is still supported.
           go-version: "^1.20"
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser (PR)
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         if: "!startsWith(github.ref, 'refs/tags')" # runs on a PR
         with:
           distribution: goreleaser
@@ -40,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser (Publish Release)
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         if: "startsWith(github.ref, 'refs/tags')" # runs on a Tag being pushed
         with:
           distribution: goreleaser

--- a/README.md
+++ b/README.md
@@ -9,41 +9,43 @@ OpenShift routes from any cert-manager Issuer.
 
 ## Prerequisites:
 
-1) Ensure you have [cert-manager](https://github.com/cert-manager/cert-manager) installed
-through the method of your choice. But make sure you install cert-manager and openshift-routes-deployment in the same namespace. By default this is in the namespace **cert-manager**.
-For example, with the regular manifest:
+1. Ensure you have [cert-manager](https://github.com/cert-manager/cert-manager) installed
+   through the method of your choice. But make sure you install cert-manager and openshift-routes-deployment in the same namespace. By default this is in the namespace **cert-manager**.
+   For example, with the regular manifest:
+
 ```sh
 oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.yaml
 ```
+
 Both **ClusterIssuer** and namespace based **Issuer** are possible. Here a **ClusterIssuer** is used:
 
-2) For example, create the ClusterIssuer (no additional ingress class is needed for the openshift-ingress router. The example.com email must be replaced by another one):
+2. For example, create the ClusterIssuer (no additional ingress class is needed for the openshift-ingress router. The example.com email must be replaced by another one):
 
 ```yaml
 apiVersion: v1
 items:
-- apiVersion: cert-manager.io/v1
-  kind: ClusterIssuer
-  metadata:
-    annotations:
-    name: letsencrypt-prod
-  spec:
-    acme:
-      email: mymail@example.com
-      preferredChain: ""
-      privateKeySecretRef:
-        name: letsencrypt-prod
-      server: https://acme-v02.api.letsencrypt.org/directory
-      solvers:
-      - http01:
-          ingress: {}
+  - apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
+      annotations:
+      name: letsencrypt-prod
+    spec:
+      acme:
+        email: mymail@example.com
+        preferredChain: ""
+        privateKeySecretRef:
+          name: letsencrypt-prod
+        server: https://acme-v02.api.letsencrypt.org/directory
+        solvers:
+          - http01:
+              ingress: {}
 ```
 
 ```sh
 oc apply -f clusterissuer.yaml
 ```
 
-3) Make sure that there is an A record on the load balancer IP or a CNAME record on the load balancer hostname in your DNS system for the HTTP-01 subdomain.
+3. Make sure that there is an A record on the load balancer IP or a CNAME record on the load balancer hostname in your DNS system for the HTTP-01 subdomain.
 
 ```
 CNAME:
@@ -60,18 +62,17 @@ oc apply -f https://github.com/cert-manager/openshift-routes/releases/latest/dow
 ```
 
 If you follow the above prerequisites, use this annotations below
+
 ```yaml
-...
+---
 metadata:
   annotations:
     cert-manager.io/issuer-kind: ClusterIssuer
     cert-manager.io/issuer-name: letsencrypt-prod
-...
+---
 spec:
   host: app.service.clustername.domain.com
-...
 ```
-
 
 Annotate your routes:
 
@@ -127,3 +128,22 @@ to be imported as a module. It has a large number of transitive dependencies tha
 amount of maintenance to whichever project we submitted it to. In the future, we would like to split
 the cert-manager APIs and typed clients out of the main cert-manager repo, at which point it would be
 easier for other people to consume in their projects.
+
+# Release Process
+
+You must have write access to this repository to perform a release.
+
+1. ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+2. Create a tag and push it:
+
+   ```bash
+   git tag v0.2.0
+   git push origin v0.2.0
+   ```
+
+3. Once the GitHub Action has completed, you will see a new GitHub Release for
+   that version. Edit the release description if needed.


### PR DESCRIPTION
I found no trace of how the release process works. I had to dig around to find it out.

I also followed up on Tim's comment https://github.com/cert-manager/openshift-routes/pull/23#discussion_r1143114009 regarding `cache: true`. The v4 of the o Action enables the cache by default, so I upgraded it from v3 to v4.

**Update Oct 2023:** I took the opportunity to bump the Go version used to build stuff from 1.20 to 1.21.

