### PR TITLE
Additional support for subject annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ metadata:
     cert-manager.io/uri-sans: "spiffe://trustdomain/workload" # Optional, no default
     cert-manager.io/private-key-algorithm: "ECDSA" # Optional, defaults to RSA
     cert-manager.io/private-key-size: "384" # Optional, defaults to 265 for ECDSA and 2048 for RSA
+    cert-manager.io/email-sans: "me@example.com,you@example.com" # Optional, no default
+    cert-manager.io/subject-organizations: "company" # Optional, no default
+    cert-manager.io/subject-organizationalunits: "company division" # Optional, no default
+    cert-manager.io/subject-countries: "My Country" # Optional, no default
+    cert-manager.io/subject-provinces: "My Province" # Optional, no default
+    cert-manager.io/subject-localities: "My City" # Optional, no default
+    cert-manager.io/subject-postalcodes: "123ABC" # Optional, no default
+    cert-manager.io/subject-streetaddresses: "1 Example St" # Optional, no default
+    cert-manager.io/subject-serialnumber: "123456" # Optional, no default
 spec:
   host: app.service.clustername.domain.com # will be added to the Subject Alternative Names of the CertificateRequest
   port:

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -57,6 +57,9 @@ func (r *Route) Reconcile(ctx context.Context, req reconcile.Request) (reconcile
 	if metav1.HasAnnotation(route.ObjectMeta, cmapi.IssuerNameAnnotationKey) {
 		log.V(5).Info("route has cert-manager annotation, reconciling", cmapi.IssuerNameAnnotationKey, route.Annotations[cmapi.IssuerNameAnnotationKey])
 		return r.sync(ctx, req, route.DeepCopy())
+	} else if metav1.HasAnnotation(route.ObjectMeta, cmapi.IngressIssuerNameAnnotationKey) {
+		log.V(5).Info("route has cert-manager annotation, reconciling", cmapi.IngressIssuerNameAnnotationKey, route.Annotations[cmapi.IngressIssuerNameAnnotationKey])
+		return r.sync(ctx, req, route.DeepCopy())
 	}
 	log.V(5).Info("ignoring route without cert-manager issuer name annotation")
 	return reconcile.Result{}, nil

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -53,6 +53,14 @@ func (r *Route) Reconcile(ctx context.Context, req reconcile.Request) (reconcile
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	if len(route.ObjectMeta.OwnerReferences) > 0 {
+		for _, o := range route.ObjectMeta.OwnerReferences {
+			if o.Kind == "Ingress" {
+				log.V(5).Info("ignoring route owned by ingress", o.Name)
+				return reconcile.Result{}, nil
+			}
+		}
+	}
 	log.V(5).Info("retrieved route")
 	if metav1.HasAnnotation(route.ObjectMeta, cmapi.IssuerNameAnnotationKey) {
 		log.V(5).Info("route has cert-manager annotation, reconciling", cmapi.IssuerNameAnnotationKey, route.Annotations[cmapi.IssuerNameAnnotationKey])

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -43,6 +43,30 @@ type Route struct {
 	log logr.Logger
 }
 
+func shouldSync(log logr.Logger, route *routev1.Route) bool {
+	if len(route.ObjectMeta.OwnerReferences) > 0 {
+		for _, o := range route.ObjectMeta.OwnerReferences {
+			if o.Kind == "Ingress" {
+				log.V(5).Info("Route is owned by an Ingress")
+				return false
+			}
+		}
+	}
+
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.IssuerNameAnnotationKey) {
+		log.V(5).Info("Route has the annotation %s=%s", cmapi.IssuerNameAnnotationKey, route.Annotations[cmapi.IssuerNameAnnotationKey])
+		return true
+	}
+
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.IngressIssuerNameAnnotationKey) {
+		log.V(5).Info("Route has the annotation %s=%s", cmapi.IngressIssuerNameAnnotationKey, route.Annotations[cmapi.IngressIssuerNameAnnotationKey])
+		return true
+	}
+
+	log.V(5).Info("Route does not have the cert-manager issuer annotation")
+	return false
+}
+
 func (r *Route) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := r.log.WithValues("object", req.NamespacedName)
 	log.V(5).Info("started reconciling")
@@ -53,24 +77,13 @@ func (r *Route) Reconcile(ctx context.Context, req reconcile.Request) (reconcile
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	if len(route.ObjectMeta.OwnerReferences) > 0 {
-		for _, o := range route.ObjectMeta.OwnerReferences {
-			if o.Kind == "Ingress" {
-				log.V(5).Info("ignoring route owned by ingress", o.Name)
-				return reconcile.Result{}, nil
-			}
-		}
-	}
 	log.V(5).Info("retrieved route")
-	if metav1.HasAnnotation(route.ObjectMeta, cmapi.IssuerNameAnnotationKey) {
-		log.V(5).Info("route has cert-manager annotation, reconciling", cmapi.IssuerNameAnnotationKey, route.Annotations[cmapi.IssuerNameAnnotationKey])
-		return r.sync(ctx, req, route.DeepCopy())
-	} else if metav1.HasAnnotation(route.ObjectMeta, cmapi.IngressIssuerNameAnnotationKey) {
-		log.V(5).Info("route has cert-manager annotation, reconciling", cmapi.IngressIssuerNameAnnotationKey, route.Annotations[cmapi.IngressIssuerNameAnnotationKey])
-		return r.sync(ctx, req, route.DeepCopy())
+
+	if !shouldSync(log, route) {
+		return reconcile.Result{}, nil
 	}
-	log.V(5).Info("ignoring route without cert-manager issuer name annotation")
-	return reconcile.Result{}, nil
+
+	return r.sync(ctx, req, route.DeepCopy())
 }
 
 func New(base logr.Logger, config *rest.Config, recorder record.EventRecorder) (*Route, error) {

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_shouldReconcile(t *testing.T) {
+	tests := []struct {
+		name  string
+		given *routev1.Route
+		want  bool
+	}{
+		{
+			name: "should reconcile with cert-manager.io/issuer-name annotation",
+			given: &routev1.Route{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"cert-manager.io/issuer-name": "test",
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "should sync with cert-manager.io/issuer annotation",
+			given: &routev1.Route{ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"cert-manager.io/issuer": "test",
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "should not sync when Route owned by Ingress",
+			given: &routev1.Route{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: "Ingress",
+					},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "should not sync when Route owned by Ingress",
+			given: &routev1.Route{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: "Ingress",
+					},
+				}},
+			},
+			want: false,
+		},
+		{
+			name:  "should not sync when no annotation is found",
+			given: &routev1.Route{ObjectMeta: metav1.ObjectMeta{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldSync(logr.Discard(), tt.given)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/controller/sync.go
+++ b/internal/controller/sync.go
@@ -575,6 +575,12 @@ func (r *Route) buildNextCR(ctx context.Context, route *routev1.Route, revision 
 		Bytes: csr,
 	})
 
+	var issuerName string
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.IngressIssuerNameAnnotationKey) {
+		issuerName = route.Annotations[cmapi.IssuerNameAnnotationKey]
+	} else {
+		issuerName = route.Annotations[cmapi.IngressIssuerNameAnnotationKey]
+	}
 	cr := &cmapi.CertificateRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: route.Name + "-",
@@ -590,7 +596,7 @@ func (r *Route) buildNextCR(ctx context.Context, route *routev1.Route, revision 
 		Spec: cmapi.CertificateRequestSpec{
 			Duration: &metav1.Duration{Duration: duration},
 			IssuerRef: cmmeta.ObjectReference{
-				Name:  route.Annotations[cmapi.IssuerNameAnnotationKey],
+				Name:  issuerName,
 				Kind:  route.Annotations[cmapi.IssuerKindAnnotationKey],
 				Group: route.Annotations[cmapi.IssuerGroupAnnotationKey],
 			},

--- a/internal/controller/sync.go
+++ b/internal/controller/sync.go
@@ -102,7 +102,6 @@ func (r *Route) sync(ctx context.Context, req reconcile.Request, route *routev1.
 			// Not a reconcile error, so don't retry this revision
 			return result, nil
 		}
-
 		// create CR and return. We own the CR so it will cause a re-reconcile
 		_, err = r.certClient.CertmanagerV1().CertificateRequests(route.Namespace).Create(ctx, cr, metav1.CreateOptions{})
 		if err != nil {
@@ -110,7 +109,6 @@ func (r *Route) sync(ctx context.Context, req reconcile.Request, route *routev1.
 		}
 		r.eventRecorder.Event(route, corev1.EventTypeNormal, ReasonIssuing, "Created new CertificateRequest for Route %s")
 		return result, nil
-
 	}
 	// is the CR Ready and Approved?
 	ready, cr, err := r.certificateRequestReadyAndApproved(ctx, route, revision)
@@ -541,7 +539,7 @@ func (r *Route) buildNextCR(ctx context.Context, route *routev1.Route, revision 
 	}
 	var serialNumber string
 	if metav1.HasAnnotation(route.ObjectMeta, cmapi.SubjectSerialNumberAnnotationKey) {
-		serialNumber = route.Annotations[cmapi.SubjectStreetAddressesAnnotationKey]
+		serialNumber = route.Annotations[cmapi.SubjectSerialNumberAnnotationKey]
 	}
 	csr, err := x509.CreateCertificateRequest(
 		rand.Reader,
@@ -577,10 +575,11 @@ func (r *Route) buildNextCR(ctx context.Context, route *routev1.Route, revision 
 
 	var issuerName string
 	if metav1.HasAnnotation(route.ObjectMeta, cmapi.IngressIssuerNameAnnotationKey) {
-		issuerName = route.Annotations[cmapi.IssuerNameAnnotationKey]
-	} else {
 		issuerName = route.Annotations[cmapi.IngressIssuerNameAnnotationKey]
+	} else {
+		issuerName = route.Annotations[cmapi.IssuerNameAnnotationKey]
 	}
+
 	cr := &cmapi.CertificateRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: route.Name + "-",

--- a/internal/controller/sync.go
+++ b/internal/controller/sync.go
@@ -33,6 +33,7 @@ import (
 	cmapiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmutil "github.com/cert-manager/cert-manager/pkg/util"
 	utilpki "github.com/cert-manager/cert-manager/pkg/util/pki"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +43,7 @@ import (
 
 const (
 	ReasonIssuing                    = `Issuing`
+	ReasonIssued                     = `Issued`
 	ReasonInvalidKey                 = `InvalidKey`
 	ReasonInvalidPrivateKeyAlgorithm = `InvalidPrivateKeyAlgorithm`
 	ReasonInvalidPrivateKeySize      = `InvalidPrivateKeySize`
@@ -121,7 +123,12 @@ func (r *Route) sync(ctx context.Context, req reconcile.Request, route *routev1.
 	}
 	// Cert is ready. Populate the route.
 	err = r.populateRoute(ctx, route, cr, revision)
+	if err != nil {
+		log.V(1).Error(err, "failed to populate route certificate")
+		return result, err
+	}
 	log.V(5).Info("populated route cert")
+	r.eventRecorder.Event(route, corev1.EventTypeNormal, ReasonIssued, "Route updated with issued certificate")
 	return result, err
 }
 
@@ -352,43 +359,6 @@ func (r *Route) buildNextCR(ctx context.Context, route *routev1.Route, revision 
 		return nil, fmt.Errorf("Invalid duration annotation on Route %s/%s", route.Namespace, route.Name)
 	}
 
-	var dnsNames []string
-	// Get the canonical hostname(s) of the Route (from .spec.host or .spec.subdomain)
-	dnsNames = getRouteHostnames(route)
-	if len(dnsNames) == 0 {
-		err := fmt.Errorf("Route is not yet initialized with a hostname")
-		r.eventRecorder.Event(route, corev1.EventTypeWarning, ReasonMissingHostname, fmt.Sprint(err))
-		return nil, err
-	}
-
-	// Parse out SANs
-	if metav1.HasAnnotation(route.ObjectMeta, cmapi.AltNamesAnnotationKey) {
-		altNames := strings.Split(route.Annotations[cmapi.AltNamesAnnotationKey], ",")
-		dnsNames = append(dnsNames, altNames...)
-	}
-	var ipSans []net.IP
-	if metav1.HasAnnotation(route.ObjectMeta, cmapi.IPSANAnnotationKey) {
-		ipAddresses := strings.Split(route.Annotations[cmapi.IPSANAnnotationKey], ",")
-		for _, i := range ipAddresses {
-			ip := net.ParseIP(i)
-			if ip != nil {
-				ipSans = append(ipSans, ip)
-			}
-		}
-	}
-	var uriSans []*url.URL
-	if metav1.HasAnnotation(route.ObjectMeta, cmapi.URISANAnnotationKey) {
-		urls := strings.Split(route.Annotations[cmapi.URISANAnnotationKey], ",")
-		for _, u := range urls {
-			ur, err := url.Parse(u)
-			if err != nil {
-				r.eventRecorder.Event(route, corev1.EventTypeWarning, ReasonInvalidValue, "Ignoring malformed URI SAN "+u)
-				continue
-			}
-			uriSans = append(uriSans, ur)
-		}
-	}
-
 	privateKeyAlgorithm, found := route.Annotations[cmapi.PrivateKeyAlgorithmAnnotationKey]
 	if !found {
 		privateKeyAlgorithm = string(cmapi.RSAKeyAlgorithm)
@@ -437,6 +407,142 @@ func (r *Route) buildNextCR(ctx context.Context, route *routev1.Route, revision 
 		return nil, fmt.Errorf("invalid private key algorithm, %s", privateKeyAlgorithm)
 	}
 
+	var dnsNames []string
+	// Get the canonical hostname(s) of the Route (from .spec.host or .spec.subdomain)
+	dnsNames = getRouteHostnames(route)
+	if len(dnsNames) == 0 {
+		err := fmt.Errorf("Route is not yet initialized with a hostname")
+		r.eventRecorder.Event(route, corev1.EventTypeWarning, ReasonMissingHostname, fmt.Sprint(err))
+		return nil, err
+	}
+
+	// Parse out SANs
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.AltNamesAnnotationKey) {
+		altNames := strings.Split(route.Annotations[cmapi.AltNamesAnnotationKey], ",")
+		dnsNames = append(dnsNames, altNames...)
+	}
+	var ipSans []net.IP
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.IPSANAnnotationKey) {
+		ipAddresses := strings.Split(route.Annotations[cmapi.IPSANAnnotationKey], ",")
+		for _, i := range ipAddresses {
+			ip := net.ParseIP(i)
+			if ip != nil {
+				ipSans = append(ipSans, ip)
+			}
+		}
+	}
+	var uriSans []*url.URL
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.URISANAnnotationKey) {
+		urls := strings.Split(route.Annotations[cmapi.URISANAnnotationKey], ",")
+		for _, u := range urls {
+			ur, err := url.Parse(u)
+			if err != nil {
+				r.eventRecorder.Event(route, corev1.EventTypeWarning, ReasonInvalidValue, "Ignoring malformed URI SAN "+u)
+				continue
+			}
+			uriSans = append(uriSans, ur)
+		}
+	}
+	var emailAddresses []string
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.EmailsAnnotationKey) {
+		emailAddresses = strings.Split(route.Annotations[cmapi.EmailsAnnotationKey], ",")
+	}
+	var organizations []string
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.SubjectOrganizationsAnnotationKey) {
+		subjectOrganizations, err := cmutil.SplitWithEscapeCSV(route.Annotations[cmapi.SubjectOrganizationsAnnotationKey])
+		organizations = subjectOrganizations
+
+		if err != nil {
+			r.log.V(1).Error(err, "the organizations annotation is invalid",
+				"object", route.Namespace+"/"+route.Name, cmapi.SubjectOrganizationsAnnotationKey,
+				route.Annotations[cmapi.SubjectOrganizationsAnnotationKey])
+			r.eventRecorder.Event(route, corev1.EventTypeWarning, ReasonInvalidValue, "annotation "+cmapi.SubjectOrganizationsAnnotationKey+": "+route.Annotations[cmapi.SubjectOrganizationsAnnotationKey]+" value is malformed")
+			return nil, err
+		}
+	}
+	var organizationalUnits []string
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.SubjectOrganizationalUnitsAnnotationKey) {
+		subjectOrganizationalUnits, err := cmutil.SplitWithEscapeCSV(route.Annotations[cmapi.SubjectOrganizationalUnitsAnnotationKey])
+		organizationalUnits = subjectOrganizationalUnits
+
+		if err != nil {
+			r.log.V(1).Error(err, "the organizational units annotation is invalid",
+				"object", route.Namespace+"/"+route.Name, cmapi.SubjectOrganizationalUnitsAnnotationKey,
+				route.Annotations[cmapi.SubjectOrganizationalUnitsAnnotationKey])
+			r.eventRecorder.Event(route, corev1.EventTypeWarning, ReasonInvalidValue, "annotation "+cmapi.SubjectOrganizationalUnitsAnnotationKey+": "+route.Annotations[cmapi.SubjectOrganizationalUnitsAnnotationKey]+" value is malformed")
+			return nil, err
+		}
+
+	}
+	var countries []string
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.SubjectCountriesAnnotationKey) {
+		subjectCountries, err := cmutil.SplitWithEscapeCSV(route.Annotations[cmapi.SubjectCountriesAnnotationKey])
+		countries = subjectCountries
+
+		if err != nil {
+			r.log.V(1).Error(err, "the countries annotation is invalid",
+				"object", route.Namespace+"/"+route.Name, cmapi.SubjectCountriesAnnotationKey,
+				route.Annotations[cmapi.SubjectCountriesAnnotationKey])
+			r.eventRecorder.Event(route, corev1.EventTypeWarning, ReasonInvalidValue, "annotation "+cmapi.SubjectCountriesAnnotationKey+": "+route.Annotations[cmapi.SubjectCountriesAnnotationKey]+" value is malformed")
+			return nil, err
+		}
+	}
+	var provinces []string
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.SubjectProvincesAnnotationKey) {
+		subjectProvinces, err := cmutil.SplitWithEscapeCSV(route.Annotations[cmapi.SubjectProvincesAnnotationKey])
+		provinces = subjectProvinces
+
+		if err != nil {
+			r.log.V(1).Error(err, "the provinces annotation is invalid",
+				"object", route.Namespace+"/"+route.Name, cmapi.SubjectProvincesAnnotationKey,
+				route.Annotations[cmapi.SubjectProvincesAnnotationKey])
+			r.eventRecorder.Event(route, corev1.EventTypeWarning, ReasonInvalidValue, "annotation "+cmapi.SubjectProvincesAnnotationKey+": "+route.Annotations[cmapi.SubjectProvincesAnnotationKey]+" value is malformed")
+			return nil, err
+		}
+	}
+	var localities []string
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.SubjectLocalitiesAnnotationKey) {
+		subjectLocalities, err := cmutil.SplitWithEscapeCSV(route.Annotations[cmapi.SubjectLocalitiesAnnotationKey])
+		localities = subjectLocalities
+
+		if err != nil {
+			r.log.V(1).Error(err, "the localities annotation is invalid",
+				"object", route.Namespace+"/"+route.Name, cmapi.SubjectLocalitiesAnnotationKey,
+				route.Annotations[cmapi.SubjectLocalitiesAnnotationKey])
+			r.eventRecorder.Event(route, corev1.EventTypeWarning, ReasonInvalidValue, "annotation "+cmapi.SubjectLocalitiesAnnotationKey+": "+route.Annotations[cmapi.SubjectLocalitiesAnnotationKey]+" value is malformed")
+			return nil, err
+		}
+	}
+	var postalCodes []string
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.SubjectPostalCodesAnnotationKey) {
+		subjectPostalCodes, err := cmutil.SplitWithEscapeCSV(route.Annotations[cmapi.SubjectPostalCodesAnnotationKey])
+		postalCodes = subjectPostalCodes
+
+		if err != nil {
+			r.log.V(1).Error(err, "the postal codes annotation is invalid",
+				"object", route.Namespace+"/"+route.Name, cmapi.SubjectPostalCodesAnnotationKey,
+				route.Annotations[cmapi.SubjectPostalCodesAnnotationKey])
+			r.eventRecorder.Event(route, corev1.EventTypeWarning, ReasonInvalidValue, "annotation "+cmapi.SubjectPostalCodesAnnotationKey+": "+route.Annotations[cmapi.SubjectPostalCodesAnnotationKey]+" value is malformed")
+			return nil, err
+		}
+	}
+	var streetAddresses []string
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.SubjectStreetAddressesAnnotationKey) {
+		subjectStreetAddresses, err := cmutil.SplitWithEscapeCSV(route.Annotations[cmapi.SubjectStreetAddressesAnnotationKey])
+		streetAddresses = subjectStreetAddresses
+
+		if err != nil {
+			r.log.V(1).Error(err, "the street addresses annotation is invalid",
+				"object", route.Namespace+"/"+route.Name, cmapi.SubjectStreetAddressesAnnotationKey,
+				route.Annotations[cmapi.SubjectStreetAddressesAnnotationKey])
+			r.eventRecorder.Event(route, corev1.EventTypeWarning, ReasonInvalidValue, "annotation "+cmapi.SubjectStreetAddressesAnnotationKey+": "+route.Annotations[cmapi.SubjectStreetAddressesAnnotationKey]+" value is malformed")
+			return nil, err
+		}
+	}
+	var serialNumber string
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.SubjectSerialNumberAnnotationKey) {
+		serialNumber = route.Annotations[cmapi.SubjectStreetAddressesAnnotationKey]
+	}
 	csr, err := x509.CreateCertificateRequest(
 		rand.Reader,
 		&x509.CertificateRequest{
@@ -444,11 +550,20 @@ func (r *Route) buildNextCR(ctx context.Context, route *routev1.Route, revision 
 			SignatureAlgorithm: signatureAlgorithm,
 			PublicKeyAlgorithm: publicKeyAlgorithm,
 			Subject: pkix.Name{
-				CommonName: route.Annotations[cmapi.CommonNameAnnotationKey],
+				CommonName:         route.Annotations[cmapi.CommonNameAnnotationKey],
+				Country:            countries,
+				Locality:           localities,
+				Organization:       organizations,
+				OrganizationalUnit: organizationalUnits,
+				PostalCode:         postalCodes,
+				Province:           provinces,
+				SerialNumber:       serialNumber,
+				StreetAddress:      streetAddresses,
 			},
-			DNSNames:    dnsNames,
-			IPAddresses: ipSans,
-			URIs:        uriSans,
+			EmailAddresses: emailAddresses,
+			DNSNames:       dnsNames,
+			IPAddresses:    ipSans,
+			URIs:           uriSans,
 		},
 		key,
 	)


### PR DESCRIPTION
Mainly adds support for additional subject annotations now supported in v1.12 of cert-manager, also upgrades cert-manager to v1.12.1 (though I see another PR for that already). 

Allow use of the `cert-manager.io/issuer` annotation, in addition to the existing `cert-manager.io/issuer-name`. This ingress annotation is more familiar for people using cert-manager on ingress already and makes switching over a bit simpler.
https://cert-manager.io/docs/usage/ingress/#supported-annotations 

Ignore routes that are owned by ingress objects as cert-manager may already be providing certificates via ingresses that openshift-controller-manager then creates and route for. This helps users like myself already using cert-manager on OpenShift via OCM ingress -> route method to slowly migrate to using `openshift-routes` on routes without the two potentially conflicting.

- feat: support subject annotations on route
- fix: ignore routes owned by ingress
- fix: support ingress issuer name annotation
- chore: upgrade cert-manager to v1.12.1