### PR TITLE
Set metrics port in deployment to default for openshift-routes

### DIFF
--- a/deploy/static/cert-manager-openshift-routes.yaml
+++ b/deploy/static/cert-manager-openshift-routes.yaml
@@ -118,7 +118,7 @@ spec:
           - containerPort: 6060
             name: readiness
             protocol: TCP
-          - containerPort: 9042
+          - containerPort: 9402
             name: metrics
             protocol: TCP
           readinessProbe:


### PR DESCRIPTION
See default in options - https://github.com/cert-manager/openshift-routes/blob/d7a6e49a1f89a3aee36b59638bdd5f6164b4a74a/internal/cmd/app/options/options.go#L127C19-L127C23