### PR TITLE
Annual review of the OWNERS file (2023): Maartje moved to Emeritus Maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 approvers:
 - munnerz
 - joshvanl
-- meyskens
 - wallrj
 - jakexks
 - maelvls


### PR DESCRIPTION
Ref: https://github.com/cert-manager/cert-manager/issues/6231