### PR TITLE
Make it possible to install openshift-routes in a different namespace than "cert-manager" using `oc process`

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -30,6 +30,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install yq
+        run: |
+          sudo curl -JL https://github.com/mikefarah/yq/releases/download/v4.35.1/yq_linux_amd64 --output /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
       - name: Run GoReleaser (PR)
         uses: goreleaser/goreleaser-action@v2
         if: "!startsWith(github.ref, 'refs/tags')" # runs on a PR

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Install in your cluster using the static manifests:
 oc apply -f https://github.com/cert-manager/openshift-routes/releases/latest/download/cert-manager-openshift-routes.yaml
 ```
 
+If you need to install it in a different namespace, you can use:
+
+```bash
+oc process -f https://github.com/cert-manager/openshift-routes/releases/latest/download/cert-manager-openshift-routes.yaml \
+  -p NAMESPACE=<NAMESPACE_NAME> | oc create -f -
+```
+
 If you follow the above prerequisites, use this annotations below
 ```yaml
 ...

--- a/deploy/static/cert-manager-openshift-routes.yaml
+++ b/deploy/static/cert-manager-openshift-routes.yaml
@@ -88,7 +88,7 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: cert-manager-openshift-routes
-    app.kubernetes.io/version: "$RELEASED_VERSION"
+    app.kubernetes.io/version: "${RELEASED_VERSION}"
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: cert-manager
 spec:
@@ -96,14 +96,14 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cert-manager-openshift-routes
-      app.kubernetes.io/version: "$RELEASED_VERSION"
+      app.kubernetes.io/version: "${RELEASED_VERSION}"
       app.kubernetes.io/component: controller
       app.kubernetes.io/part-of: cert-manager
   template:
     metadata:
       labels:
         app.kubernetes.io/name: cert-manager-openshift-routes
-        app.kubernetes.io/version: "$RELEASED_VERSION"
+        app.kubernetes.io/version: "${RELEASED_VERSION}"
         app.kubernetes.io/component: controller
         app.kubernetes.io/part-of: cert-manager
     spec:
@@ -111,7 +111,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: cert-manager-openshift-routes
-          image: "ghcr.io/cert-manager/cert-manager-openshift-routes:$RELEASED_VERSION"
+          image: "ghcr.io/cert-manager/cert-manager-openshift-routes:${RELEASED_VERSION}"
           args:
             - -v=5
           ports:

--- a/deploy/static/cert-manager-openshift-routes.yaml
+++ b/deploy/static/cert-manager-openshift-routes.yaml
@@ -114,6 +114,7 @@ spec:
           image: "ghcr.io/cert-manager/cert-manager-openshift-routes:${RELEASED_VERSION}"
           args:
             - -v=5
+            - -leader-election-namespace=kube-system
           ports:
             - containerPort: 6060
               name: readiness

--- a/deploy/static/cert-manager-openshift-routes.yaml
+++ b/deploy/static/cert-manager-openshift-routes.yaml
@@ -4,62 +4,62 @@ kind: ClusterRole
 metadata:
   name: cert-manager-openshift-routes
 rules:
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-  - update
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes/custom-host
-  verbs:
-  - create
-  - update
-- apiGroups:
-  - cert-manager.io
-  resources:
-  - certificaterequests
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-    - cert-manager.io
-  resources:
-    - certificaterequests/status
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - get
-  - list
-  - update
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes/custom-host
+    verbs:
+      - create
+      - update
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificaterequests
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificaterequests/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -77,9 +77,9 @@ roleRef:
   kind: ClusterRole
   name: cert-manager-openshift-routes
 subjects:
-- kind: ServiceAccount
-  name: cert-manager-openshift-routes
-  namespace: cert-manager
+  - kind: ServiceAccount
+    name: cert-manager-openshift-routes
+    namespace: cert-manager
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -113,14 +113,14 @@ spec:
         - name: cert-manager-openshift-routes
           image: "ghcr.io/cert-manager/cert-manager-openshift-routes:$RELEASED_VERSION"
           args:
-          - -v=5
+            - -v=5
           ports:
-          - containerPort: 6060
-            name: readiness
-            protocol: TCP
-          - containerPort: 9402
-            name: metrics
-            protocol: TCP
+            - containerPort: 6060
+              name: readiness
+              protocol: TCP
+            - containerPort: 9402
+              name: metrics
+              protocol: TCP
           readinessProbe:
             httpGet:
               port: readiness

--- a/deploy/static/cert-manager-openshift-routes.yaml
+++ b/deploy/static/cert-manager-openshift-routes.yaml
@@ -65,7 +65,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cert-manager-openshift-routes
-  namespace: cert-manager
+  namespace: ${NAMESPACE}
 automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -79,13 +79,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cert-manager-openshift-routes
-    namespace: cert-manager
+    namespace: ${NAMESPACE}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cert-manager-openshift-routes
-  namespace: cert-manager
+  namespace: ${NAMESPACE}
   labels:
     app.kubernetes.io/name: cert-manager-openshift-routes
     app.kubernetes.io/version: "${RELEASED_VERSION}"

--- a/hack/generate-static-manifest.sh
+++ b/hack/generate-static-manifest.sh
@@ -4,6 +4,37 @@ if [ $# -ne 1 ]; then
     echo "Usage: $0 RELEASED_VERSION"
     exit 1
 fi
+
+# First, let's generate the static manifest that can be used with `kubectl apply
+# -f`.
 export RELEASED_VERSION="$1"
-envsubst < "./deploy/static/cert-manager-openshift-routes.yaml" > "cert-manager-openshift-routes-$RELEASED_VERSION.yaml"
+export NAMESPACE=cert-manager
+envsubst <"./deploy/static/cert-manager-openshift-routes.yaml" >"cert-manager-openshift-routes-$RELEASED_VERSION.yaml"
+
+# Next, let's generate the static manifest that can be used with `oc process -p
+# NAMESPACE=foo -f`.
+export NAMESPACE='${NAMESPACE}'
+envsubst <"./deploy/static/cert-manager-openshift-routes.yaml" \
+    | yq ea '[.]' ./deploy/static/cert-manager-openshift-routes.yaml \
+    | yq "$(
+        cat <<'EOF'
+{
+    "apiVersion": "template.openshift.io/v1",
+    "kind": "Template",
+    "metadata": {
+        "name":"cert-manager-openshift-routes-deploy"
+    },
+    "objects": .,
+    "parameters": [
+        {
+            "name": "NAMESPACE",
+            "description": "Namespace where openshift-routes should be installed.",
+            "value": "cert-manager",
+            "required": true
+        }
+    ]
+}
+EOF
+    )" \
+        >"cert-manager-openshift-routes-$RELEASED_VERSION-tpl.yaml"
 exit 0


### PR DESCRIPTION
This is a continuation of https://github.com/cert-manager/openshift-routes/pull/32. This PR focuses on a very precise request coming from people relying on the `oc process` command to substitute variables such as `$NAMESPACE` in the static manifest.

To test this PR, run the following:

```bash
oc process -f https://raw.githubusercontent.com/maelvls/openshift-routes/different-namespace/deploy/static/cert-manager-openshift-routes.yaml \
  -p NAMESPACE=<NAMESPACE_NAME> \
  | oc create -f -