### PR TITLE
Add Helm chart for openshift-routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,24 @@ CNAME:
   Alias: your-lb-domain.cloud
 ```
 
-## Usage
+## Installation
 
-Install in your cluster using the static manifests:
+The openshift-routes component can be installed using the static manifests:
 
 ```shell
 oc apply -f https://github.com/cert-manager/openshift-routes/releases/latest/download/cert-manager-openshift-routes.yaml
 ```
+
+or with the provided Helm chart:
+
+```shell
+git clone https://github.com/cert-manager/openshift-routes.git
+helm install "openshift-routes" ./openshift-routes/deploy/chart
+```
+
+Please review the [values.yaml](./deploy/chart/values.yaml) file for all configuration options.
+
+## Usage
 
 If you follow the above prerequisites, use this annotations below
 ```yaml

--- a/deploy/chart/.helmignore
+++ b/deploy/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: openshift-routes
+description: A Helm chart to deploy openshift-routes adapter for cert-manager on Kubernetes
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0

--- a/deploy/chart/templates/_helpers.tpl
+++ b/deploy/chart/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openshift-routes.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "openshift-routes.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openshift-routes.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "openshift-routes.labels" -}}
+helm.sh/chart: {{ include "openshift-routes.chart" . }}
+{{ include "openshift-routes.selectorLabels" . }}
+app.kubernetes.io/component: controller
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "openshift-routes.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openshift-routes.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "openshift-routes.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "openshift-routes.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+The final, full image reference
+*/}}
+{{- define "openshift-routes.image" -}}
+{{- if .Values.image.digest }}
+{{- .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}
+{{- else }}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag }}
+{{- end }}
+{{- end }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openshift-routes.fullname" . }}
+  labels:
+    {{- include "openshift-routes.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "openshift-routes.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "openshift-routes.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: true
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "openshift-routes.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: openshift-routes
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "openshift-routes.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-v={{ .Values.logLevel }}"
+            - "--leader-election-namespace={{ .Release.Namespace }}"
+          ports:
+          - containerPort: 6060
+            name: readiness
+            protocol: TCP
+          {{- if .Values.metrics.enabled }}
+          - containerPort: 9402
+            name: metrics
+            protocol: TCP
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              port: readiness
+              path: "/readyz"
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/chart/templates/rbac.yaml
+++ b/deploy/chart/templates/rbac.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "openshift-routes.fullname" . }}
+  labels:
+    {{- include "openshift-routes.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificaterequests
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+    - cert-manager.io
+  resources:
+    - certificaterequests/status
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "openshift-routes.fullname" . }}
+  labels:
+    {{- include "openshift-routes.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "openshift-routes.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "openshift-routes.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/chart/templates/service.yaml
+++ b/deploy/chart/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openshift-routes.fullname" . }}
+  labels:
+    {{- include "openshift-routes.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "openshift-routes.selectorLabels" . | nindent 4 }}
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: 9402
+    targetPort: metrics
+    protocol: TCP
+{{- end }}

--- a/deploy/chart/templates/serviceaccount.yaml
+++ b/deploy/chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openshift-routes.serviceAccountName" . }}
+  labels:
+    {{- include "openshift-routes.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  automountServiceAccountToken: false
+{{- end }}

--- a/deploy/chart/templates/servicemonitor.yaml
+++ b/deploy/chart/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openshift-routes.fullname" . }}
+  labels:
+    {{- include "openshift-routes.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  - honorLabels: false
+    interval: {{ .Values.metrics.serviceMonitor.interval }}
+    path: /metrics
+    scrapeTimeout: 15s
+    targetPort: metrics
+  selector:
+    matchLabels:
+      {{- include "openshift-routes.labels" . | nindent 6 }}
+{{- end }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,0 +1,70 @@
+# Default values for openshift-routes.
+
+replicas: 1
+logLevel: 5
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  # https://github.com/cert-manager/openshift-routes/pkgs/container/cert-manager-openshift-routes
+  registry: ghcr.io
+  repository: cert-manager/cert-manager-openshift-routes
+  # the final image is generated as "${registry}/${repostiory}:${tag}"
+  tag: "0.2.0"
+  # if "digest" is set, overrides "tag"
+  # digest: "sha256:..."
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+rbac:
+  # create (Cluster-) Roles and RoleBindings for the ServiceAccount
+  create: true
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+metrics:
+  # when enabled, a service is created that exposes the metrics endpoint
+  enabled: false
+  serviceMonitor:
+    # when enabled, a ServiceMonitor object is created - note that his requires the monitoring.coreos.com CRDs!
+    enabled: false
+    interval: 60s


### PR DESCRIPTION
This PR adds a Helm chart for openshift-routes. This allows users to deploy the component with the Helm CLI, or GitOps tools such as ArgoCD or FluxCD.