### PR TITLE
Upload Helm chart as OCI artifact to GCHR

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,13 @@ project_name: cert-manager-openshift-routes
 before:
   hooks:
     - go test -v ./...
+    # update static manifests
     - ./hack/generate-static-manifest.sh {{ .Version }}
+    # update and package new Helm chart
+    - helm package ./deploy/chart --version {{ trimprefix .Version "v"}} --app-version {{ .Version }}
+    # upload Helm chart as OCI artifact to GitHub Container Registry
+    - '{{if .IsSnapshot}}echo SKIPPING: {{end}}helm push ./openshift-routes-{{ trimprefix .Version "v"}}.tgz oci://ghcr.io/cert-manager/cert-manager-openshift-routes:{{ .Version }}-chart'
+
 builds:
   - id: cert-manager-openshift-routes
     main: ./internal/cmd
@@ -133,4 +139,5 @@ release:
   extra_files:
     - glob: ./cert-manager-openshift-routes-*.yaml
       name_template: cert-manager-openshift-routes.yaml
-
+    - glob: ./openshift-routes-*.tgz
+      name_template: openshift-routes-chart.tgz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
     # update and package new Helm chart
     - helm package ./deploy/chart --version {{ trimprefix .Version "v"}} --app-version {{ .Version }}
     # upload Helm chart as OCI artifact to GitHub Container Registry
-    - '{{if .IsSnapshot}}echo SKIPPING: {{end}}helm push ./openshift-routes-{{ trimprefix .Version "v"}}.tgz oci://ghcr.io/cert-manager/cert-manager-openshift-routes:{{ .Version }}-chart'
+    - '{{if .IsSnapshot}}echo SKIPPING: {{end}}helm push ./openshift-routes-{{ trimprefix .Version "v"}}.tgz oci://ghcr.io/cert-manager/charts'
 
 builds:
   - id: cert-manager-openshift-routes
@@ -25,8 +25,8 @@ builds:
       - riscv64
       - ppc64le
     goarm:
-      - '6'
-      - '7'
+      - "6"
+      - "7"
 archives:
   - format: tar.gz
     format_overrides:
@@ -132,7 +132,7 @@ docker_manifests:
       - ghcr.io/cert-manager/cert-manager-openshift-routes:{{ .Version }}-riscv64
       - ghcr.io/cert-manager/cert-manager-openshift-routes:{{ .Version }}-ppc64le
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 release:
   draft: true
   replace_existing_draft: true


### PR DESCRIPTION
Hi @maelvls ,

as discussed in https://github.com/cert-manager/openshift-routes/pull/41 , I'm adding the functionality to automatically update and push the Helm chart as an OCI artifact to Github's container registry.

Please give it a try since I'm not familiar with the usual release process and goreleaser - feel free to make changes as necessary.