### PR TITLE
Implement E-mail SAN annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ metadata:
     cert-manager.io/alt-names: "mycooldomain.com,mysecondarydomain.com" # Optional, no default
     cert-manager.io/ip-sans: "10.20.30.40,192.168.192.168" # Optional, no default
     cert-manager.io/uri-sans: "spiffe://trustdomain/workload" # Optional, no default
+    cert-manager.io/email-sans: "me@example.com,you@example.com" # Optional, no default
     cert-manager.io/private-key-algorithm: "ECDSA" # Optional, defaults to RSA
 spec:
   host: app.service.clustername.domain.com # will be added to the Subject Alternative Names of the CertificateRequest

--- a/internal/controller/sync.go
+++ b/internal/controller/sync.go
@@ -388,6 +388,10 @@ func (r *Route) buildNextCR(ctx context.Context, route *routev1.Route, revision 
 			uriSans = append(uriSans, ur)
 		}
 	}
+	emailSans := []string{}
+	if metav1.HasAnnotation(route.ObjectMeta, cmapi.EmailsAnnotationKey) {
+		emailSans = strings.Split(route.Annotations[cmapi.EmailsAnnotationKey], ",")
+	}
 
 	privateKeyAlgorithm, found := route.Annotations[cmapi.PrivateKeyAlgorithmAnnotationKey]
 	if !found {
@@ -446,9 +450,10 @@ func (r *Route) buildNextCR(ctx context.Context, route *routev1.Route, revision 
 			Subject: pkix.Name{
 				CommonName: route.Annotations[cmapi.CommonNameAnnotationKey],
 			},
-			DNSNames:    dnsNames,
-			IPAddresses: ipSans,
-			URIs:        uriSans,
+			DNSNames:       dnsNames,
+			IPAddresses:    ipSans,
+			URIs:           uriSans,
+			EmailAddresses: emailSans,
 		},
 		key,
 	)


### PR DESCRIPTION
Similar to `Ingress` integration in cert-manager:
- Added `cert-manager.io/email-sans` annotation to configure spec.emailAddresses field for the Certificate to be generated.
- Implement test case for all SANs