### PR TITLE
Add namespace value for configuring the destination namespace

### DIFF
--- a/deploy/chart/templates/_helpers.tpl
+++ b/deploy/chart/templates/_helpers.tpl
@@ -31,6 +31,15 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Namespace for all resources to be installed into
+If not defined in values file then the helm release namespace is used
+By default this is not set so the helm release namespace will be used
+*/}}
+{{- define "openshift-routes.namespace" -}}
+    {{ .Values.namespace | default .Release.Namespace }}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "openshift-routes.labels" -}}

--- a/deploy/chart/templates/_helpers.tpl
+++ b/deploy/chart/templates/_helpers.tpl
@@ -33,7 +33,11 @@ Create chart name and version as used by the chart label.
 {{/*
 Namespace for all resources to be installed into
 If not defined in values file then the helm release namespace is used
-By default this is not set so the helm release namespace will be used
+By default this is not set so the helm release namespace will be used.
+
+
+This gets around an problem within Helm discussed in
+https://github.com/helm/helm/issues/5358.
 */}}
 {{- define "openshift-routes.namespace" -}}
     {{ .Values.namespace | default .Release.Namespace }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "openshift-routes.fullname" . }}
+  namespace: {{ include "openshift-routes.namespace" . }}
   labels:
     {{- include "openshift-routes.labels" . | nindent 4 }}
 spec:

--- a/deploy/chart/templates/service.yaml
+++ b/deploy/chart/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "openshift-routes.fullname" . }}
+  namespace: {{ include "openshift-routes.namespace" . }}
   labels:
     {{- include "openshift-routes.labels" . | nindent 4 }}
 spec:

--- a/deploy/chart/templates/serviceaccount.yaml
+++ b/deploy/chart/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "openshift-routes.serviceAccountName" . }}
+  namespace: {{ include "openshift-routes.namespace" . }}
   labels:
     {{- include "openshift-routes.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/deploy/chart/templates/servicemonitor.yaml
+++ b/deploy/chart/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "openshift-routes.fullname" . }}
+  namespace: {{ include "openshift-routes.namespace" . }}
   labels:
     {{- include "openshift-routes.labels" . | nindent 4 }}
 spec:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -5,6 +5,9 @@ logLevel: 5
 nameOverride: ""
 fullnameOverride: ""
 
+# This namespace allows you to define where the services are installed into.
+# If not set then they use the namespace of the release.
+# This is helpful when installing cert manager as a chart dependency (sub chart).
 namespace: ""
 
 image:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -5,6 +5,8 @@ logLevel: 5
 nameOverride: ""
 fullnameOverride: ""
 
+namespace: ""
+
 image:
   # https://github.com/cert-manager/openshift-routes/pkgs/container/cert-manager-openshift-routes
   # the final image is generated as "${registry}/${repostiory}:${tag|digest}"


### PR DESCRIPTION
Option for configuring the namespace for all resources to be installed into.
If not defined in values file then the helm release namespace is used.
By default this is not set so the helm release namespace will be used.