### PR TITLE
Helm: add `omitHelmLabels` so that people can generate static manifests without the Helm-specific labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 _bin
 bin
+dist/
 
 # Test binary, build with `go test -c`
 *.test

--- a/deploy/charts/openshift-routes/README.md
+++ b/deploy/charts/openshift-routes/README.md
@@ -216,5 +216,12 @@ Create a ServiceMonitor to add openshift-routes to Prometheus.
 > ```
 
 The interval to scrape metrics.
+#### **omitHelmLabels** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Omit Helm-specific labels. This is useful when generating a static manifest with `helm template`.
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/openshift-routes/templates/_helpers.tpl
+++ b/deploy/charts/openshift-routes/templates/_helpers.tpl
@@ -48,10 +48,15 @@ https://github.com/helm/helm/issues/5358.
 Common labels
 */}}
 {{- define "openshift-routes.labels" -}}
-helm.sh/chart: {{ include "openshift-routes.chart" . }}
-{{ include "openshift-routes.selectorLabels" . }}
-app.kubernetes.io/component: controller
+{{/*
+You can generate generate a static manifest free of Helm-specific labels by
+using `--set omitHelmLabels=true`.
+*/}}
+{{- include "openshift-routes.selectorLabels" . }}
+{{- if not .Values.omitHelmLabels }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "openshift-routes.chart" . }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -59,7 +64,11 @@ Selector labels
 */}}
 {{- define "openshift-routes.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "openshift-routes.name" . }}
+app.kubernetes.io/component: controller
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- if not .Values.omitHelmLabels }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end}}
 {{- end }}
 
 {{/*

--- a/deploy/charts/openshift-routes/templates/_helpers.tpl
+++ b/deploy/charts/openshift-routes/templates/_helpers.tpl
@@ -53,6 +53,7 @@ You can generate generate a static manifest free of Helm-specific labels by
 using `--set omitHelmLabels=true`.
 */}}
 {{- include "openshift-routes.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- if not .Values.omitHelmLabels }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "openshift-routes.chart" . }}
@@ -65,7 +66,6 @@ Selector labels
 {{- define "openshift-routes.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "openshift-routes.name" . }}
 app.kubernetes.io/component: controller
-app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- if not .Values.omitHelmLabels }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end}}

--- a/deploy/charts/openshift-routes/templates/_helpers.tpl
+++ b/deploy/charts/openshift-routes/templates/_helpers.tpl
@@ -54,6 +54,7 @@ using `--set omitHelmLabels=true`.
 */}}
 {{- include "openshift-routes.selectorLabels" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/component: controller
 {{- if not .Values.omitHelmLabels }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "openshift-routes.chart" . }}
@@ -65,7 +66,6 @@ Selector labels
 */}}
 {{- define "openshift-routes.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "openshift-routes.name" . }}
-app.kubernetes.io/component: controller
 {{- if not .Values.omitHelmLabels }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end}}

--- a/deploy/charts/openshift-routes/templates/deployment.yaml
+++ b/deploy/charts/openshift-routes/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "openshift-routes.selectorLabels" . | nindent 8 }}
+        {{- include "openshift-routes.labels" . | nindent 8 }}
     spec:
       automountServiceAccountToken: true
       {{- with .Values.imagePullSecrets }}

--- a/deploy/charts/openshift-routes/values.schema.json
+++ b/deploy/charts/openshift-routes/values.schema.json
@@ -33,6 +33,9 @@
         "nodeSelector": {
           "$ref": "#/$defs/helm-values.nodeSelector"
         },
+        "omitHelmLabels": {
+          "$ref": "#/$defs/helm-values.omitHelmLabels"
+        },
         "podAnnotations": {
           "$ref": "#/$defs/helm-values.podAnnotations"
         },
@@ -179,6 +182,11 @@
       },
       "description": "The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels. For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).\n\nThis default ensures that Pods are only scheduled to Linux nodes. It prevents Pods being scheduled to Windows nodes in a mixed OS cluster.",
       "type": "object"
+    },
+    "helm-values.omitHelmLabels": {
+      "default": false,
+      "description": "Omit Helm-specific labels. This is useful when generating a static manifest with `helm template`.",
+      "type": "boolean"
     },
     "helm-values.podAnnotations": {
       "default": {},

--- a/deploy/charts/openshift-routes/values.yaml
+++ b/deploy/charts/openshift-routes/values.yaml
@@ -84,7 +84,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
   readOnlyRootFilesystem: true
 
 # Kubernetes pod resources
@@ -143,3 +143,7 @@ metrics:
 
     # The interval to scrape metrics.
     interval: 60s
+
+# Omit Helm-specific labels. This is useful when generating a static manifest
+# with `helm template`.
+omitHelmLabels: false


### PR DESCRIPTION
In https://github.com/cert-manager/openshift-routes/issues/73, I wondered how users could continue using a static manifests (e.g., for ArgoCD using the "static manifests" pattern). In this PR, I propose to add a Helm value to help with generating a static manifest free of Helm-specific labels.

To generate a static manifest free of Helm-specific labels, you will now be able to run:

```bash
helm template deploy/charts/openshift-routes/ --set omitHelmLabels=true 
```

The only two labels and labelSelectors left are the three non-Helm-specific labels:

```yaml
labels:
  app.kubernetes.io/name: openshift-routes
  app.kubernetes.io/component: controller
  app.kubernetes.io/version: v0.6.0-alpha.0
```

Here are the labels that get removed when using `--set omitHelmLabels=true`:

```bash
make helm-chart VERSION=v0.6.0-alpha.0
diff -u \
  <(helm template --show-only templates/deployment.yaml _bin/scratch/image/openshift-routes-0.6.0-alpha.0.tgz) \
  <(helm template --show-only templates/deployment.yaml _bin/scratch/image/openshift-routes-0.6.0-alpha.0.tgz --set omitHelmLabels=true)
```

```diff
--- helm template --show-only templates/deployment.yaml
+++ helm template --show-only templates/deployment.yaml --set omitHelmLabels=true
@@ -9,9 +9,6 @@
     app.kubernetes.io/name: openshift-routes
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: 0.6.0-alpha.0
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: openshift-routes-0.6.0-alpha.0
 spec:
   replicas: 1
   selector:
@@ -19,14 +16,12 @@
       app.kubernetes.io/name: openshift-routes
       app.kubernetes.io/component: controller
       app.kubernetes.io/version: 0.6.0-alpha.0
-      app.kubernetes.io/instance: release-name
   template:
     metadata:
       labels:
         app.kubernetes.io/name: openshift-routes
         app.kubernetes.io/component: controller
         app.kubernetes.io/version: 0.6.0-alpha.0
-        app.kubernetes.io/instance: release-name
     spec:
       automountServiceAccountToken: true
       serviceAccountName: release-name-openshift-routes
```

Difference between the old v0.5.0 static manifest and the static manifest you would get using `--set omitHelmLabels=true`:

```bash
make helm-chart VERSION=v0.6.0-alpha.0
diff -u \
  <(curl -sSL https://github.com/cert-manager/openshift-routes/releases/download/v0.5.0/cert-manager-openshift-routes.yaml) \
  <(helm template openshift-routes -n cert-manager _bin/scratch/image/openshift-routes-0.6.0-alpha.0.tgz --set omitHelmLabels=true)
```

```diff
--- curl -sSL https://github.com/cert-manager/openshift-routes/releases/download/v0.5.0/cert-manager-openshift-routes.yaml
+++ helm template openshift-routes -n cert-manager _bin/scratch/image/openshift-routes-0.6.0-alpha.0.tgz --set omitHelmLabels=true
@@ -1,8 +1,25 @@
 ---
+# Source: openshift-routes/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift-routes
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: openshift-routes
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/version: 0.6.0-alpha.0
+automountServiceAccountToken: false
+---
+# Source: openshift-routes/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cert-manager-openshift-routes
+  name: openshift-routes
+  labels:
+    app.kubernetes.io/name: openshift-routes
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/version: 0.6.0-alpha.0
 rules:
 - apiGroups:
   - route.openshift.io
@@ -61,66 +78,71 @@
   - list
   - update
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cert-manager-openshift-routes
-  namespace: cert-manager
-automountServiceAccountToken: false
----
+# Source: openshift-routes/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cert-manager-openshift-routes
+  name: openshift-routes
+  labels:
+    app.kubernetes.io/name: openshift-routes
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/version: 0.6.0-alpha.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cert-manager-openshift-routes
+  name: openshift-routes
 subjects:
 - kind: ServiceAccount
-  name: cert-manager-openshift-routes
+  name: openshift-routes
   namespace: cert-manager
 ---
+# Source: openshift-routes/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cert-manager-openshift-routes
+  name: openshift-routes
   namespace: cert-manager
   labels:
-    app.kubernetes.io/name: cert-manager-openshift-routes
-    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/name: openshift-routes
     app.kubernetes.io/component: controller
-    app.kubernetes.io/part-of: cert-manager
+    app.kubernetes.io/version: 0.6.0-alpha.0
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: cert-manager-openshift-routes
-      app.kubernetes.io/version: "0.5.0"
+      app.kubernetes.io/name: openshift-routes
       app.kubernetes.io/component: controller
-      app.kubernetes.io/part-of: cert-manager
+      app.kubernetes.io/version: 0.6.0-alpha.0
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: cert-manager-openshift-routes
-        app.kubernetes.io/version: "0.5.0"
+        app.kubernetes.io/name: openshift-routes
         app.kubernetes.io/component: controller
-        app.kubernetes.io/part-of: cert-manager
+        app.kubernetes.io/version: 0.6.0-alpha.0
     spec:
-      serviceAccountName: cert-manager-openshift-routes
       automountServiceAccountToken: true
+      serviceAccountName: openshift-routes
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - name: cert-manager-openshift-routes
-          image: "ghcr.io/cert-manager/cert-manager-openshift-routes:0.5.0"
+        - name: openshift-routes
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          image: "ghcr.io/cert-manager/cert-manager-openshift-routes:v0.6.0-alpha.0"
+          imagePullPolicy: IfNotPresent
           args:
-          - -v=5
+            - "-v=5"
+            - "--leader-election-namespace=cert-manager"
           ports:
           - containerPort: 6060
             name: readiness
             protocol: TCP
-          - containerPort: 9402
-            name: metrics
-            protocol: TCP
           readinessProbe:
             httpGet:
               port: readiness
@@ -128,3 +150,7 @@
             initialDelaySeconds: 3
             periodSeconds: 5
             timeoutSeconds: 3
+          resources:
+            {}
+      nodeSelector:
+        kubernetes.io/os: linux
```
