### PR TITLE
Use v-prefixed value for appVersion in Helm chart

### DIFF
--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -33,6 +33,7 @@ deploy_namespace := cert-manager
 helm_chart_source_dir := deploy/charts/openshift-routes
 helm_chart_name := openshift-routes
 helm_chart_version := $(VERSION:v%=%)
+helm_chart_app_version := $(VERSION)
 helm_labels_template_name := cert-manager-openshift-routes.labels
 helm_docs_use_helm_tool := 1
 helm_generate_schema := 1


### PR DESCRIPTION
We want the helm chart version to be without "v", because it is hosted in a OCI registry.
However, the appVersion value in the Chart.yaml file should be with the "v" prefix to match the controller's image tag.