### PR TITLE
limit-namespaces for namespace-scope deployments

### DIFF
--- a/internal/cmd/app/app.go
+++ b/internal/cmd/app/app.go
@@ -26,11 +26,14 @@ import (
 	routescheme "github.com/openshift/client-go/route/clientset/versioned/scheme"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/cert-manager/openshift-routes/internal/cmd/app/options"
@@ -85,6 +88,17 @@ func Command() *cobra.Command {
 				return fmt.Errorf("connected to the Kubernetes API, but the cert-manager v1 CRDs do not appear to be installed")
 			}
 
+			// Load in Cache Configs for limited namespaces
+			cacheConfig := map[string]cache.Config{}
+			if len(opts.LimitNamespaces) > 0 {
+				for _, ns := range opts.LimitNamespaces {
+					cacheConfig[ns] = cache.Config{
+						LabelSelector: labels.Everything(),
+						FieldSelector: fields.Everything(),
+					}
+				}
+			}
+
 			logger := opts.Logr.WithName("controller-manager")
 			eventBroadcaster := record.NewBroadcaster()
 			eventBroadcaster.StartLogging(func(format string, args ...interface{}) {
@@ -104,6 +118,7 @@ func Command() *cobra.Command {
 
 			mgr, err := ctrl.NewManager(opts.RestConfig, ctrl.Options{
 				Scheme:                        combinedScheme,
+				Cache:                         cache.Options{DefaultNamespaces: cacheConfig},
 				Logger:                        logger,
 				LeaderElection:                opts.EnableLeaderElection,
 				LeaderElectionID:              "cert-manager-openshift-routes",

--- a/internal/cmd/app/options/options.go
+++ b/internal/cmd/app/options/options.go
@@ -57,6 +57,9 @@ type Options struct {
 
 	logLevel        string
 	kubeConfigFlags *genericclioptions.ConfigFlags
+
+	// LimitNamespaces is the list of namespaces to which cert-manager-openshift will limit itself for reconciliation
+	LimitNamespaces []string
 }
 
 func New() *Options {
@@ -134,4 +137,8 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.LeaderElectionNamespace,
 		"leader-election-namespace", "cert-manager",
 		"Namespace to create leader election resources in.")
+
+	fs.StringSliceVar(&o.LimitNamespaces,
+		"limit-namespaces", []string{""},
+		"List of comma ',' delimited namespaces within which openshift-routes will operator on resources")
 }


### PR DESCRIPTION
Implement the limit-namespace argument for the manager, this enables the manager to run in a namespace-scoped configuration.

This allows users in constrained OpenShift environments, such as those running multi-tenant clusters, a more convenient deployment method, without running into permission issues, and eventual crash looping due to inadequate RBAC.

By default, the implementation will retain cluster-wide configuration. If the --limit-namespaces argument is passed with a list of comma-delimited namespaces, the manager will be configured to only list and watch resources within the provided namespaces.

Not sure if this is really useful for anyone else, but it is a change I had to implement for one of our internal deployments to work.

Without getting into too much detail, we have an internal cluster that serves a pretty large number of tenants. No tenant is allowed access to cluster-wide resources, and their permissions are scoped to only the namespaces owned by that tenant. This meant that we weren't able to user the openshift-routes cert manager as-is, as it was trying to request resources outside our tenant's scope, and as we weren't able to add the RBAC to make this work out of the box, we had to make this change.